### PR TITLE
feat: admin token auth for bookmarks management

### DIFF
--- a/src/app/api/bookmarks/route.ts
+++ b/src/app/api/bookmarks/route.ts
@@ -1,9 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
 import { bookmarksStorage } from '@/lib/bookmarks-storage'
-import {
-  saveTweetSchema,
-  tweetListParamsSchema,
-} from '@/lib/bookmarks-schema'
+import { saveTweetSchema, tweetListParamsSchema } from '@/lib/bookmarks-schema'
 import { hasAdminAccess } from '@/lib/auth'
 import {
   createErrorResponse,
@@ -28,8 +25,9 @@ export async function GET(request: NextRequest) {
 
     const params = tweetListParamsSchema.parse(paramsObj)
 
+    // 未认证时默认返回公开推文
     if (!params.public && !hasAdminAccess(request)) {
-      return createErrorResponse('Unauthorized', 401)
+      params.public = true
     }
 
     const result = await bookmarksStorage.listTweets(params)

--- a/src/app/api/bookmarks/tags/route.ts
+++ b/src/app/api/bookmarks/tags/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest } from 'next/server'
 import { bookmarksStorage } from '@/lib/bookmarks-storage'
-import { hasAdminAccess } from '@/lib/auth'
 import {
   createErrorResponse,
   createSuccessResponse,
@@ -16,10 +15,6 @@ export async function GET(request: NextRequest) {
   const rateLimitResult = bookmarksRateLimit(request)
   if (!rateLimitResult.allowed) {
     return createErrorResponse('Rate limit exceeded', 429)
-  }
-
-  if (!hasAdminAccess(request)) {
-    return createErrorResponse('Unauthorized', 401)
   }
 
   try {

--- a/src/app/bookmarks/save/SaveTweetClient.tsx
+++ b/src/app/bookmarks/save/SaveTweetClient.tsx
@@ -1,19 +1,15 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useSearchParams, useRouter } from 'next/navigation'
 import { Bookmark, Copy, Check } from 'lucide-react'
+import { getAdminToken, isAdmin } from '@/lib/admin-token'
 
 function getAuthHeaders(): HeadersInit {
-  const urlParams = new URLSearchParams(window.location.search)
-  const username = urlParams.get('username')
-  const password = urlParams.get('password')
-
-  if (username && password) {
-    const credentials = btoa(`${username}:${password}`)
-    return { Authorization: `Basic ${credentials}` }
+  const token = getAdminToken()
+  if (token) {
+    return { Authorization: `Bearer ${token}` }
   }
-
   return {}
 }
 
@@ -95,6 +91,24 @@ export default function SaveTweetClient() {
             保存成功！
           </h2>
           <p className='text-gray-600 dark:text-gray-400'>推文已添加到收藏</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!isAdmin()) {
+    return (
+      <div className='min-h-screen flex items-center justify-center p-4'>
+        <div className='text-center'>
+          <h2 className='text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2'>
+            需要管理员权限
+          </h2>
+          <p className='text-gray-600 dark:text-gray-400 mb-4'>
+            请在浏览器控制台设置 admin_token 后刷新页面
+          </p>
+          <code className='block bg-gray-100 dark:bg-gray-800 text-sm p-3 rounded-lg text-left'>
+            {`localStorage.setItem('admin_token', btoa('username:password'))`}
+          </code>
         </div>
       </div>
     )

--- a/src/lib/admin-token.ts
+++ b/src/lib/admin-token.ts
@@ -1,0 +1,18 @@
+const ADMIN_TOKEN_KEY = 'admin_token'
+
+export function getAdminToken(): string | null {
+  if (typeof window === 'undefined') return null
+  return localStorage.getItem(ADMIN_TOKEN_KEY)
+}
+
+export function setAdminToken(token: string): void {
+  localStorage.setItem(ADMIN_TOKEN_KEY, token)
+}
+
+export function removeAdminToken(): void {
+  localStorage.removeItem(ADMIN_TOKEN_KEY)
+}
+
+export function isAdmin(): boolean {
+  return !!getAdminToken()
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -77,10 +77,16 @@ export function getAuthFromRequest(request: Request): AdminCredentials | null {
     return { username, password }
   }
 
-  // 方式3: Authorization header
+  // 方式3: Authorization header (Basic)
   const authHeader = request.headers.get('Authorization')
   if (authHeader && authHeader.startsWith('Basic ')) {
     const token = authHeader.substring(6)
+    return parseAuthToken(token)
+  }
+
+  // 方式4: Authorization header (Bearer) - token 格式与 Basic 一致 (base64(username:password))
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    const token = authHeader.substring(7)
     return parseAuthToken(token)
   }
 


### PR DESCRIPTION
## 改动说明

用 localStorage admin token 替代 URL 参数认证，实现收藏页面的权限控制：

- **公开浏览**：所有人可以直接访问 `/bookmarks` 查看公开推文，无需认证
- **管理操作**：添加/编辑/删除/导出需要 admin token，通过浏览器控制台设置一次即可

### 具体改动

- 新增 `src/lib/admin-token.ts`：客户端 localStorage token 工具
- `src/lib/auth.ts`：新增 Bearer token 认证方式
- `src/app/api/bookmarks/route.ts`：未认证 GET 请求默认返回公开推文（不再 401）
- `src/app/api/bookmarks/tags/route.ts`：移除认证要求，标签公开可用
- `src/app/bookmarks/BookmarksClient.tsx`：从 localStorage 读 token，按权限显示管理按钮
- `src/app/bookmarks/save/SaveTweetClient.tsx`：无 token 时显示提示而非表单

### 使用方式

浏览器控制台执行一次：
```js
localStorage.setItem('admin_token', btoa('admin:password'))
```
刷新页面即可看到管理按钮。