### PR TITLE
fix: bookmarks stale cache + Chrome extension UX improvements

### DIFF
--- a/extensions/save-tweet/content.js
+++ b/extensions/save-tweet/content.js
@@ -1,13 +1,54 @@
-// content.js - Inject save buttons into X/Twitter timeline
 const PROCESSED_ATTR = 'data-blog-save-injected'
 const STATUS_RE = /\/(\w+)\/status\/(\d+)/
+const DEDUP_KEY = 'blog_saved_tweets'
+const TTL_MS = 20 * 24 * 60 * 60 * 1000
 
 const SAVE_SVG =
-  '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z"/></svg>'
+  '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/></svg>'
+
+const SAVED_SVG =
+  '<svg viewBox="0 0 24 24" width="18" height="18" fill="#00ba7c" stroke="#00ba7c" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>'
+
+const BLOG_SVG =
+  '<svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>'
+
+function getSavedTweets() {
+  try {
+    const raw = localStorage.getItem(DEDUP_KEY)
+    if (!raw) return {}
+    const data = JSON.parse(raw)
+    const now = Date.now()
+    const cleaned = {}
+    let changed = false
+    for (const url in data) {
+      if (now - data[url] < TTL_MS) {
+        cleaned[url] = data[url]
+      } else {
+        changed = true
+      }
+    }
+    if (changed) localStorage.setItem(DEDUP_KEY, JSON.stringify(cleaned))
+    return cleaned
+  } catch (e) {
+    return {}
+  }
+}
+
+function markTweetSaved(url) {
+  const data = getSavedTweets()
+  data[url] = Date.now()
+  localStorage.setItem(DEDUP_KEY, JSON.stringify(data))
+}
+
+function isTweetSaved(url) {
+  const data = getSavedTweets()
+  return !!data[url]
+}
 
 function getTweetUrl(article) {
   const links = article.querySelectorAll('a[href*="/status/"]')
-  for (const link of links) {
+  for (let i = 0; i < links.length; i++) {
+    const link = links[i]
     if (link.querySelector('time')) {
       const match = link.getAttribute('href').match(STATUS_RE)
       if (match) return 'https://x.com/' + match[1] + '/status/' + match[2]
@@ -16,16 +57,100 @@ function getTweetUrl(article) {
   return null
 }
 
+function showToast(message, blogUrl) {
+  const existing = document.getElementById('blog-save-toast')
+  if (existing) existing.remove()
+
+  const toast = document.createElement('div')
+  toast.id = 'blog-save-toast'
+  toast.style.cssText =
+    'position:fixed;bottom:24px;left:50%;transform:translateX(-50%);z-index:999999;' +
+    'background:#1a1a2e;color:#fff;padding:12px 20px;border-radius:12px;' +
+    'font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;font-size:14px;' +
+    'box-shadow:0 8px 32px rgba(0,0,0,0.3);display:flex;align-items:center;gap:12px;' +
+    'animation:blogToastIn 0.3s ease;max-width:420px;'
+
+  const style = document.createElement('style')
+  style.textContent =
+    '@keyframes blogToastIn{from{opacity:0;transform:translateX(-50%) translateY(20px)}' +
+    'to{opacity:1;transform:translateX(-50%) translateY(0)}}' +
+    '@keyframes blogToastOut{from{opacity:1;transform:translateX(-50%) translateY(0)}' +
+    'to{opacity:0;transform:translateX(-50%) translateY(20px)}}'
+  document.head.appendChild(style)
+
+  const checkSvg =
+    '<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="#00ba7c" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>'
+
+  toast.innerHTML =
+    '<span style="display:flex;align-items:center;flex-shrink:0">' +
+    checkSvg +
+    '</span>' +
+    '<span>' +
+    message +
+    '</span>'
+
+  if (blogUrl) {
+    const link = document.createElement('a')
+    link.href = blogUrl
+    link.target = '_blank'
+    link.rel = 'noopener noreferrer'
+    link.textContent = '查看'
+    link.style.cssText =
+      'color:#60a5fa;text-decoration:none;font-weight:500;white-space:nowrap;margin-left:4px;'
+    link.addEventListener('mouseenter', function () {
+      link.style.textDecoration = 'underline'
+    })
+    link.addEventListener('mouseleave', function () {
+      link.style.textDecoration = 'none'
+    })
+    toast.appendChild(link)
+  }
+
+  const closeBtn = document.createElement('button')
+  closeBtn.innerHTML = '&times;'
+  closeBtn.style.cssText =
+    'background:none;border:none;color:#999;font-size:18px;cursor:pointer;padding:0 0 0 4px;line-height:1;'
+  closeBtn.addEventListener('click', function () {
+    toast.style.animation = 'blogToastOut 0.2s ease forwards'
+    setTimeout(function () {
+      toast.remove()
+    }, 200)
+  })
+  toast.appendChild(closeBtn)
+
+  document.body.appendChild(toast)
+
+  setTimeout(function () {
+    if (document.getElementById('blog-save-toast')) {
+      toast.style.animation = 'blogToastOut 0.2s ease forwards'
+      setTimeout(function () {
+        toast.remove()
+      }, 200)
+    }
+  }, 5000)
+}
+
 function createSaveButton(tweetUrl) {
+  const alreadySaved = isTweetSaved(tweetUrl)
   const btn = document.createElement('button')
   btn.className = 'blog-save-btn'
-  btn.title = 'Save to Blog'
-  btn.innerHTML = SAVE_SVG
+  btn.title = alreadySaved ? 'Already saved to Blog' : 'Save to Blog'
+  btn.innerHTML = alreadySaved ? SAVED_SVG : BLOG_SVG
   btn.style.cssText =
-    'display:inline-flex;align-items:center;gap:4px;padding:4px 8px;border:none;background:transparent;color:#536471;cursor:pointer;border-radius:9999px;font-size:13px;transition:all 0.2s;'
+    'display:inline-flex;align-items:center;gap:4px;padding:4px 8px;border:none;' +
+    'background:transparent;color:' +
+    (alreadySaved ? '#00ba7c' : '#536471') +
+    ';cursor:pointer;border-radius:9999px;font-size:13px;transition:all 0.2s;'
+
+  if (alreadySaved) {
+    btn.dataset.saved = 'true'
+  }
+
   btn.addEventListener('mouseenter', function () {
-    btn.style.background = 'rgba(29,155,240,0.1)'
-    btn.style.color = '#1d9bf0'
+    if (!btn.dataset.saved) {
+      btn.style.background = 'rgba(29,155,240,0.1)'
+      btn.style.color = '#1d9bf0'
+    }
   })
   btn.addEventListener('mouseleave', function () {
     if (!btn.dataset.saved) {
@@ -36,6 +161,10 @@ function createSaveButton(tweetUrl) {
   btn.addEventListener('click', function (e) {
     e.stopPropagation()
     e.preventDefault()
+    if (btn.dataset.saved) {
+      showToast('这条推文已经保存过了', null)
+      return
+    }
     saveTweet(btn, tweetUrl)
   })
   return btn
@@ -43,28 +172,41 @@ function createSaveButton(tweetUrl) {
 
 async function saveTweet(btn, url) {
   btn.disabled = true
-  btn.innerHTML = '...'
+  btn.innerHTML =
+    '<svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10" stroke-dasharray="32" stroke-dashoffset="32"><animate attributeName="stroke-dashoffset" values="32;0" dur="1s" repeatCount="indefinite"/><animateTransform attributeName="transform" type="rotate" values="0 12 12;360 12 12" dur="1s" repeatCount="indefinite"/></circle></svg>'
   try {
     const resp = await chrome.runtime.sendMessage({
       type: 'SAVE_TWEET',
       url: url,
     })
     if (resp && resp.error) throw new Error(resp.error)
-    btn.innerHTML = '\u2713'
+
+    markTweetSaved(url)
+    btn.innerHTML = SAVED_SVG
     btn.style.color = '#00ba7c'
+    btn.style.background = 'transparent'
     btn.dataset.saved = 'true'
-    setTimeout(function () {
-      btn.innerHTML = SAVE_SVG
-      btn.style.color = '#00ba7c'
-    }, 1000)
+    btn.title = 'Already saved to Blog'
+
+    let blogUrl = ''
+    try {
+      const config = await chrome.storage.sync.get(['apiUrl'])
+      blogUrl =
+        (config.apiUrl || 'https://www.talljack.me').replace(/\/+$/, '') +
+        '/bookmarks/public'
+    } catch (e) {
+      blogUrl = ''
+    }
+    showToast('推文已保存到博客', blogUrl)
   } catch (err) {
-    btn.innerHTML = SAVE_SVG
+    btn.innerHTML = BLOG_SVG
     btn.style.color = '#f4212e'
     btn.title = err.message || 'Save failed'
+    showToast('保存失败: ' + (err.message || '未知错误'), null)
     setTimeout(function () {
       btn.style.color = '#536471'
       btn.title = 'Save to Blog'
-    }, 2000)
+    }, 3000)
   } finally {
     btn.disabled = false
   }

--- a/extensions/save-tweet/manifest.json
+++ b/extensions/save-tweet/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Save Tweet to Blog",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Save X/Twitter tweets to your blog bookmarks",
   "permissions": ["activeTab", "storage", "tabs"],
   "host_permissions": [

--- a/src/lib/security.ts
+++ b/src/lib/security.ts
@@ -158,7 +158,7 @@ export function createSuccessResponse(
 
   const responseHeaders = {
     'Content-Type': 'application/json',
-    'Cache-Control': 'public, max-age=60, s-maxage=60',
+    'Cache-Control': 'no-store, no-cache, must-revalidate',
     ...headers,
   }
 


### PR DESCRIPTION
## Summary

- Fix deleted tweets reappearing after page refresh (cache bug)
- Fix new tweets not showing until cache expires
- Improve Chrome extension with dedup, new icon, and success toast

## Root Cause: Stale Cache

`createSuccessResponse` in `security.ts` was setting `Cache-Control: public, max-age=60, s-maxage=60` on ALL API responses including bookmarks. After deleting a tweet, the browser served the cached (stale) response on refresh. Same issue caused newly added tweets to not appear.

**Fix**: Changed to `no-store, no-cache, must-revalidate` for API responses.

## Chrome Extension Improvements (v1.2.0)

1. **Dedup with 20-day TTL**: Saved tweet URLs stored in `localStorage` with timestamps. Expired entries auto-cleaned on read. Already-saved tweets show green checkmark and block re-save.

2. **New icon**: Changed from bookmark icon (identical to X's native bookmark) to a book icon to avoid confusion.

3. **Toast notifications**: Success toast with "查看" link to `/bookmarks/public`. Failure toast with error message. Auto-dismiss after 5s with close button.

4. **Loading state**: Animated spinner SVG during save request.

## Verification
- Build passes
- All 16 bookmarks e2e tests pass