### PR TITLE
feat: capture and display tweet text in bookmarks

### DIFF
--- a/extensions/save-tweet/background.js
+++ b/extensions/save-tweet/background.js
@@ -1,32 +1,34 @@
 // background.js - Service worker for save-tweet extension
 chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
   if (message.type === 'SAVE_TWEET') {
-    handleSaveTweet(message.url).then(sendResponse)
+    handleSaveTweet(message.url, message.text).then(sendResponse)
     return true
   }
 })
 
-async function handleSaveTweet(url) {
+async function handleSaveTweet(url, text) {
   try {
     const data = await chrome.storage.sync.get(['apiUrl', 'token'])
     if (!data.token)
       return { error: 'No token configured. Open extension options.' }
     const base = (data.apiUrl || 'https://www.talljack.me').replace(/\/+$/, '')
+    const body = { url: url, tags: [], notes: '', isPublic: true }
+    if (text) body.metadata = { text: text }
     const res = await fetch(base + '/api/bookmarks', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         Authorization: 'Bearer ' + data.token,
       },
-      body: JSON.stringify({ url: url, tags: [], notes: '', isPublic: true }),
+      body: JSON.stringify(body),
     })
     if (!res.ok) {
-      const body = await res.json().catch(function () {
+      const errorBody = await res.json().catch(function () {
         return {}
       })
-      return { error: body.error || 'HTTP ' + res.status }
+      return { error: errorBody.error || 'HTTP ' + res.status }
     }
-    return { success: true }
+    return { success: true, base: base }
   } catch (err) {
     return { error: err.message || 'Network error' }
   }

--- a/src/components/TweetCard.tsx
+++ b/src/components/TweetCard.tsx
@@ -98,23 +98,32 @@ export default function TweetCard({
         </div>
 
         {!embedLoaded && (
-          <div className='flex items-center gap-3 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700'>
-            <svg
-              className='w-5 h-5 text-blue-400 shrink-0'
-              viewBox='0 0 24 24'
-              fill='currentColor'
-              aria-hidden='true'
-            >
-              <path d='M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z' />
-            </svg>
-            <a
-              href={tweet.url}
-              target='_blank'
-              rel='noopener noreferrer'
-              className='text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium'
-            >
-              查看 @{tweet.authorUsername} 的推文 →
-            </a>
+          <div className='flex flex-col gap-3 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700'>
+            {tweet.metadata?.text && (
+              <p className='text-sm text-gray-800 dark:text-gray-200 leading-relaxed whitespace-pre-wrap break-words'>
+                {tweet.metadata.text.length > 280
+                  ? tweet.metadata.text.slice(0, 280) + '…'
+                  : tweet.metadata.text}
+              </p>
+            )}
+            <div className='flex items-center gap-3'>
+              <svg
+                className='w-4 h-4 text-blue-400 shrink-0'
+                viewBox='0 0 24 24'
+                fill='currentColor'
+                aria-hidden='true'
+              >
+                <path d='M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z' />
+              </svg>
+              <a
+                href={tweet.url}
+                target='_blank'
+                rel='noopener noreferrer'
+                className='text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium'
+              >
+                查看 @{tweet.authorUsername} 的推文 →
+              </a>
+            </div>
           </div>
         )}
 

--- a/src/lib/bookmarks-schema.ts
+++ b/src/lib/bookmarks-schema.ts
@@ -4,10 +4,8 @@ export const tweetUrlSchema = z
   .string()
   .url()
   .refine(
-    (url) => {
-      const match = url.match(
-        /(?:twitter\.com|x\.com)\/(\w+)\/status\/(\d+)/
-      )
+    url => {
+      const match = url.match(/(?:twitter\.com|x\.com)\/(\w+)\/status\/(\d+)/)
       return match !== null
     },
     {
@@ -20,6 +18,12 @@ export const saveTweetSchema = z.object({
   tags: z.array(z.string().min(1).max(50)).max(10).optional().default([]),
   notes: z.string().max(5000).optional().default(''),
   isPublic: z.boolean().optional().default(false),
+  metadata: z
+    .object({
+      authorName: z.string().max(100).optional(),
+      text: z.string().max(5000).optional(),
+    })
+    .optional(),
 })
 
 export const updateTweetSchema = z.object({

--- a/src/lib/bookmarks-storage.ts
+++ b/src/lib/bookmarks-storage.ts
@@ -31,6 +31,10 @@ export class BookmarksStorage {
     tags: string[]
     notes: string
     isPublic: boolean
+    metadata?: {
+      authorName?: string
+      text?: string
+    }
   }): Promise<Tweet> {
     const tweetInfo = extractTweetInfo(data.url)
     if (!tweetInfo) {
@@ -49,6 +53,7 @@ export class BookmarksStorage {
       tags: data.tags,
       notes: data.notes,
       isPublic: data.isPublic,
+      ...(data.metadata && { metadata: data.metadata }),
     }
 
     if (isRedisConfigured()) {


### PR DESCRIPTION
## Summary

- Extension `content.js` extracts tweet body text via `[data-testid="tweetText"]` on save and passes it to `background.js`
- `background.js` includes `metadata: { text }` in the POST `/api/bookmarks` request
- `bookmarks-schema.ts` adds optional `metadata` field to `saveTweetSchema`
- `bookmarks-storage.ts` persists `metadata` when saving a tweet
- `TweetCard` now shows `metadata.text` (truncated to 280 chars) as fallback content when Twitter embed fails to load

## Test plan

- [ ] Save a new tweet via the extension — verify the tweet text is captured and stored
- [ ] Visit `/bookmarks` or `/bookmarks/public` — verify the tweet text appears in cards where Twitter embed is unavailable
- [ ] Verify text longer than 280 chars is truncated with `…`
- [ ] Verify existing bookmarks without `metadata.text` still show the link-only fallback as before
- [ ] Verify the Twitter embed still loads normally when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)