### PR TITLE
Improve saved tweet content display in bookmarks

### DIFF
--- a/docs/plans/2026-03-01-bookmarks-tweet-content-design.md
+++ b/docs/plans/2026-03-01-bookmarks-tweet-content-design.md
@@ -1,0 +1,143 @@
+# Bookmarks Tweet Content Capture And List Preview Design
+
+## Summary
+
+Fix the bookmarks flow so newly saved tweets persist captured tweet text and the bookmarks list shows readable content before the outbound tweet link. The change only applies to newly saved tweets. Existing bookmarks without captured text remain unchanged.
+
+## Goals
+
+- Persist `metadata.text` reliably for new tweet bookmarks in both Redis and file storage modes.
+- Show tweet text preview first in bookmark list items.
+- Clamp preview text to 5 lines, with overflow ellipsis.
+- Keep the original tweet URL visible as a secondary action.
+- Preserve X embed support as an optional secondary section instead of the primary reading surface.
+
+## Non-Goals
+
+- No backfill or migration for previously saved bookmarks.
+- No automatic refetch of tweet text for historical records.
+- No changes to bookmark creation UX beyond existing extension capture.
+
+## Current Problem
+
+The browser extension already extracts tweet text and sends it as `metadata.text`, but the saved result is not consistently usable in the bookmarks UI.
+
+Two issues exist:
+
+1. Redis storage writes `metadata` directly into a hash payload, which is not a stable way to persist nested structured data for later typed reads.
+2. `TweetCard` only renders `metadata.text` when the X embed fails to load, so the list still behaves like a link-first or embed-first UI instead of a content-first bookmarks view.
+
+## Proposed Approach
+
+### 1. Normalize metadata persistence
+
+Update `BookmarksStorage` so tweet metadata is serialized before writing to Redis and parsed after reading from Redis.
+
+Recommended shape:
+
+- Store top-level tweet fields as hash fields.
+- Store `metadata` as a JSON string field when present.
+- On `getTweet`, `listTweetsFromRedis`, and `exportAllTweets`, parse the metadata field back into an object.
+
+File storage remains unchanged because JSON file persistence already supports nested objects.
+
+This makes the Redis and file storage return shape consistent for:
+
+- `tweet.metadata.text`
+- `tweet.metadata.authorName`
+
+### 2. Make list items content-first
+
+Update `TweetCard` so the bookmark list item always prefers the saved text preview when available.
+
+New rendering order:
+
+1. Tweet text preview block
+2. Link row (`查看 @username 的推文`)
+3. Optional tags, notes, metadata row, and actions
+4. Optional X embed area
+
+The text preview becomes the primary content block instead of a fallback shown only when embed loading fails.
+
+### 3. Keep embed as secondary enrichment
+
+Preserve the current X widget loading behavior, but treat it as enhancement only.
+
+- The main bookmark content must be readable before the widget loads.
+- If the widget loads successfully, show it below the preview/link section.
+- If the widget fails or is blocked, no user-facing functionality is lost.
+
+## UX Details
+
+### Text preview
+
+- Render `tweet.metadata?.text` when present.
+- Preserve line breaks with `whitespace-pre-wrap`.
+- Limit display to 5 lines.
+- Use visual truncation for overflow.
+- Avoid empty placeholder UI when no text exists.
+
+### Link placement
+
+- Always show the original tweet link beneath the preview.
+- Use the existing username-based label.
+- Keep the link target opening in a new tab.
+
+### Old bookmarks
+
+- If `metadata.text` is missing, the card falls back to showing the link and existing metadata/actions only.
+- No recovery or backfill attempt is made.
+
+## Data Flow
+
+### Save flow
+
+1. Content script extracts tweet text from `[data-testid="tweetText"]`.
+2. Background script sends `metadata.text` to `POST /api/bookmarks`.
+3. API validates `metadata.text` with existing schema.
+4. Storage layer serializes metadata for Redis persistence.
+5. Read APIs deserialize metadata before returning tweet data to the client.
+
+### Read flow
+
+1. Bookmarks pages fetch tweets from `/api/bookmarks`.
+2. Returned tweet objects include parsed `metadata`.
+3. `TweetCard` renders preview text first when `metadata.text` exists.
+4. X embed loads independently without blocking core content visibility.
+
+## Error Handling
+
+- If the extension cannot extract text, save still succeeds with URL-only data.
+- If Redis metadata parsing fails for a record, treat that bookmark as having no metadata rather than failing the whole list request.
+- If X widget loading fails, keep preview and link visible.
+
+## Testing Scope
+
+### Storage
+
+- Saving a new tweet with `metadata.text` persists readable metadata in Redis mode.
+- Reading a saved tweet returns `metadata` as an object, not a raw string.
+- List and export endpoints continue returning valid tweet objects.
+
+### UI
+
+- New bookmarks with text show a 5-line preview before the link.
+- Bookmarks without text do not render an empty preview block.
+- Preview remains visible whether embed loads or not.
+
+### Search regression
+
+- Search by words from `metadata.text` still matches bookmarks after metadata serialization changes.
+
+## Implementation Notes
+
+- Prefer a small pair of helper functions in `bookmarks-storage.ts` for serializing and parsing bookmark records.
+- Keep the UI change localized to `TweetCard` unless a shared text clamp utility is already present.
+- Avoid introducing a data migration in this change set.
+
+## Success Criteria
+
+- Newly saved tweets show human-readable text content in bookmarks list items.
+- The list item presents preview text first and link second.
+- Old bookmarks continue to render without errors.
+- The feature works the same in Redis-backed and file-backed environments.

--- a/src/components/TweetCard.tsx
+++ b/src/components/TweetCard.tsx
@@ -55,6 +55,7 @@ export default function TweetCard({
 }: TweetCardProps) {
   const tweetRef = useRef<HTMLDivElement>(null)
   const [embedLoaded, setEmbedLoaded] = useState(false)
+  const previewText = tweet.metadata?.text?.trim()
 
   useEffect(() => {
     if (typeof window === 'undefined' || !tweetRef.current) return
@@ -86,46 +87,46 @@ export default function TweetCard({
     document.documentElement.classList.contains('dark')
 
   return (
-    <article className='py-6 border-b border-gray-100 dark:border-gray-800 last:border-b-0'>
+    <article
+      className='py-6 border-b border-gray-100 dark:border-gray-800 last:border-b-0'
+      data-testid='tweet-card'
+    >
       <div className='space-y-4'>
-        <div ref={tweetRef} className='tweet-embed-container'>
-          <blockquote
-            className='twitter-tweet'
-            data-theme={isDarkMode ? 'dark' : 'light'}
-          >
-            <a href={tweet.url}>@{tweet.authorUsername} 的推文</a>
-          </blockquote>
-        </div>
+        <div className='flex flex-col gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-800/50'>
+          {previewText && (
+            <p
+              data-testid='tweet-preview'
+              className='text-sm leading-relaxed whitespace-pre-wrap break-words text-gray-800 dark:text-gray-200'
+              style={{
+                display: '-webkit-box',
+                WebkitBoxOrient: 'vertical',
+                WebkitLineClamp: 5,
+                overflow: 'hidden',
+              }}
+            >
+              {previewText}
+            </p>
+          )}
 
-        {!embedLoaded && (
-          <div className='flex flex-col gap-3 p-4 bg-gray-50 dark:bg-gray-800/50 rounded-lg border border-gray-200 dark:border-gray-700'>
-            {tweet.metadata?.text && (
-              <p className='text-sm text-gray-800 dark:text-gray-200 leading-relaxed whitespace-pre-wrap break-words'>
-                {tweet.metadata.text.length > 280
-                  ? tweet.metadata.text.slice(0, 280) + '…'
-                  : tweet.metadata.text}
-              </p>
-            )}
-            <div className='flex items-center gap-3'>
-              <svg
-                className='w-4 h-4 text-blue-400 shrink-0'
-                viewBox='0 0 24 24'
-                fill='currentColor'
-                aria-hidden='true'
-              >
-                <path d='M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z' />
-              </svg>
-              <a
-                href={tweet.url}
-                target='_blank'
-                rel='noopener noreferrer'
-                className='text-blue-600 dark:text-blue-400 hover:underline text-sm font-medium'
-              >
-                查看 @{tweet.authorUsername} 的推文 →
-              </a>
-            </div>
+          <div data-testid='tweet-link-row' className='flex items-center gap-3'>
+            <svg
+              className='h-4 w-4 shrink-0 text-blue-400'
+              viewBox='0 0 24 24'
+              fill='currentColor'
+              aria-hidden='true'
+            >
+              <path d='M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z' />
+            </svg>
+            <a
+              href={tweet.url}
+              target='_blank'
+              rel='noopener noreferrer'
+              className='text-sm font-medium text-blue-600 hover:underline dark:text-blue-400'
+            >
+              查看 @{tweet.authorUsername} 的推文 →
+            </a>
           </div>
-        )}
+        </div>
 
         <div className='space-y-3'>
           {tweet.tags.length > 0 && (
@@ -209,6 +210,24 @@ export default function TweetCard({
               </div>
             )}
           </div>
+        </div>
+
+        <div
+          ref={tweetRef}
+          className={`overflow-hidden transition-all duration-200 ${
+            embedLoaded
+              ? 'max-h-[1200px] opacity-100'
+              : 'pointer-events-none max-h-0 opacity-0'
+          }`}
+          aria-hidden={!embedLoaded}
+          data-testid='tweet-embed-container'
+        >
+          <blockquote
+            className='twitter-tweet'
+            data-theme={isDarkMode ? 'dark' : 'light'}
+          >
+            <a href={tweet.url}>@{tweet.authorUsername} 的推文</a>
+          </blockquote>
         </div>
       </div>
     </article>


### PR DESCRIPTION
## Summary
- persist saved tweet metadata reliably in Redis-backed bookmark storage
- show saved tweet text before the outbound tweet link in bookmark cards
- add regression coverage for metadata roundtrip and preview-first rendering

## Verification
- npm run type-check
- npm run build
- manually verified on next start at http://localhost:3102 that POST /api/bookmarks stores metadata.text and /bookmarks/public renders preview text above the link