### PR TITLE
Fix extension save flow after reload

### DIFF
--- a/extensions/save-tweet/manifest.json
+++ b/extensions/save-tweet/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Save Tweet to Blog",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Save X/Twitter tweets to your blog bookmarks",
   "permissions": ["activeTab", "storage", "tabs"],
   "host_permissions": [


### PR DESCRIPTION
## Summary
- recover from stale content-script contexts after the extension is reloaded so save clicks stop failing with Extension context invalidated
- improve tweet content extraction with fallback selectors before sending bookmark metadata
- let the popup save path request the current tweet text from the active tab before posting

## Verification
- node --check extensions/save-tweet/content.js
- node --check extensions/save-tweet/popup.js
- node --check extensions/save-tweet/background.js
- npx eslint extensions/save-tweet/content.js extensions/save-tweet/popup.js extensions/save-tweet/background.js extensions/save-tweet/options.js
- npm run type-check